### PR TITLE
Adds weighted loss to the kgcn learner

### DIFF
--- a/kglib/kgcn/pipeline/pipeline.py
+++ b/kglib/kgcn/pipeline/pipeline.py
@@ -44,7 +44,8 @@ def pipeline(graphs,
              attr_embedding_dim=6,
              edge_output_size=3,
              node_output_size=3,
-             output_dir=None):
+             output_dir=None,
+             use_weighted=False):
 
     ############################################################
     # Manipulate the graph data
@@ -83,7 +84,8 @@ def pipeline(graphs,
 
     learner = KGCNLearner(kgcn,
                           num_processing_steps_tr=num_processing_steps_tr,
-                          num_processing_steps_ge=num_processing_steps_ge)
+                          num_processing_steps_ge=num_processing_steps_ge,
+                          use_weighted=use_weighted)
 
     train_values, test_values, tr_info = learner(tr_input_graphs,
                                                  tr_target_graphs,


### PR DESCRIPTION
## What is the goal of this PR?

The goal of this PR is to be able to use weighted (to the label prevalence) loss for the kgcn learner. This is especially valuable if the labels are not equally distributed.

## What are the changes implemented in this PR?

These changes only affect the two loss functions: loss_ops_preexisting_no_penalty and  loss_ops_from_difference we calculate the label prevalence and calculate a weight from the prevalence using this function: weights = (1 / (label_prevalence + 1) this results in a balanced weighing of the label weights. The default functionality is set to not using weighted loss so this should not impact others.
